### PR TITLE
Small fixes

### DIFF
--- a/vkill.el
+++ b/vkill.el
@@ -2,9 +2,11 @@
 
 ;; Copyright (C) 1987, 1989 Kyle E. Jones
 ;; Copyright (C) 1991, 93, 96, 2000 Noah S. Friedman
+;; Copyright (C) 2015 Heikki Lehväslaiho
 
 ;; Author: Kyle E. Jones <kyle@uunet.uu.net>
 ;;         Noah Friedman <friedman@splode.com>
+;;         Heikki Lehväslaiho  <heikki.lehvaslaiho@gmail.com>
 ;; Maintainer: friedman@splode.com
 
 ;; $Id: vkill.el,v 1.7 2002/03/20 18:48:18 friedman Exp $
@@ -33,6 +35,10 @@
 
 ;;; ChangeLog:
 
+;;  2015-06-05  Heikki Lehväslaiho  <heikki.lehvaslaiho@gmail.com>
+;;
+;;      * vkill.el (vkill, list-unix-processes) autoload automatically
+;;
 ;; 2002-03-20  Noah Friedman  <friedman@splode.com>
 ;;
 ;; 	* vkill.el (vkill-ps-command): Convert user-uid to string for concat.
@@ -161,6 +167,7 @@ operating systems.")
 
 (defun vkill-abs (n) (if (< n 0) (- n) n))
 
+;;;###autoload
 (defun vkill (&optional list)
   "Mode for displaying all UNIX processes owned by the current user
 \(all the processes on the system if invoked by the superuser) and allowing
@@ -215,6 +222,7 @@ Commands:
 (fset 'vkill-mode 'vkill)
 (put 'vkill-mode 'mode-class 'special)
 
+;;;###autoload
 (defun list-unix-processes (&optional activate)
   "List UNIX processes owned by the current user using the ps(1) command.
 If run by the superuser, all processes are listed.  The buffer used to

--- a/vkill.el
+++ b/vkill.el
@@ -26,15 +26,17 @@
 ;; mvoe around in it marking processes to be sent a signal.  Type a `?'
 ;; in the Process Info buffer for more help.
 ;;
-;; The commands vkill and list-unix-processes are the package entry points.
-;;
-;; To autoload, use
-;;     (autoload 'vkill "vkill" nil t)
-;;     (autoload 'list-unix-processes "vkill" nil t)
-;; in your .emacs file.
+;; The commands vkill and list-unix-processes are the autoloaded
+;; package entry points.
 
 ;;; ChangeLog:
 
+;;  2015-06-05  Heikki Lehväslaiho  <heikki.lehvaslaiho@gmail.com>
+;;
+;;      * vkill.el fix compiler warnings
+;;      goto-line: use forward-line instead
+;;      next-line: use forward-line instead
+;;
 ;;  2015-06-05  Heikki Lehväslaiho  <heikki.lehvaslaiho@gmail.com>
 ;;
 ;;      * vkill.el (vkill, list-unix-processes) autoload automatically
@@ -212,7 +214,8 @@ Commands:
     (if (or new list)
 	(progn
 	  (vkill-update-process-info list)
-	  (goto-line 2)))
+          (goto-char (point-min))
+          (forward-line 1)))
 
     (if list
 	(display-buffer vkill-buffer)
@@ -248,7 +251,7 @@ corrseponding processes.  A negative COUNT means move backwards."
 	    (insert "*")
 	    (delete-char 1)))
       (forward-line direction)
-      (next-line 0) ; move to goal column.
+      (forward-line 0) ; move to goal column.
       (vkill-decrement count))))
 
 (defun vkill-mark-all-processes ()
@@ -256,7 +259,8 @@ corrseponding processes.  A negative COUNT means move backwards."
   (interactive)
   (save-excursion
     (let (buffer-read-only)
-      (goto-line 2)
+      (goto-char (point-min))
+      (forward-line 1)
       (while (not (eobp))
 	(insert "*")
 	(delete-char 1)
@@ -325,7 +329,8 @@ processes."
       (and (boundp 'vkill-command-column-regexp)
            (re-search-forward vkill-command-column-regexp nil t)
            (setq goal-column (1- (match-beginning 0)))))
-    (goto-line 2)
+    (goto-char (point-min))
+    (forward-line 1)
     (sort-numeric-fields 2 (point) (point-max)))
   (or quietly (input-pending-p)
       (message "Updating process information... done.")))

--- a/vkill.el
+++ b/vkill.el
@@ -23,7 +23,7 @@
 ;;; Commentary:
 
 ;; M-x vkill creates a buffer containing ps(1) output and allows you to
-;; mvoe around in it marking processes to be sent a signal.  Type a `?'
+;; move around in it marking processes to be sent a signal.  Type a `?'
 ;; in the Process Info buffer for more help.
 ;;
 ;; The commands vkill and list-unix-processes are the autoloaded


### PR DESCRIPTION
1. I could not see why the user needs to autoload the interactive functions. Better it happens automatically. No need to configure in .emacs at all.

2. Compiler complains about usage of interactive only functions. Fixed those.

3. A simple typo.